### PR TITLE
support filters kwargs

### DIFF
--- a/piex/explorer.py
+++ b/piex/explorer.py
@@ -32,6 +32,14 @@ class PipelineExplorer:
         self.dfs = dict()
 
     def _filter(self, df, filters):
+        """Filter table df on equality filters
+
+        For example, if filters := ``{'data_modality': 'graph'}``, then only rows in the table that have the data_modality column equal to 'graph' will be returned.
+
+        Args:
+            df (DataFrame)
+                filters (dict): mapping of column names -> values to check for equality
+        """
         df = df.loc[(df[list(filters)] == pd.Series(filters)).all(axis=1)]
         return df.reset_index(drop=True).copy()
 

--- a/piex/explorer.py
+++ b/piex/explorer.py
@@ -251,14 +251,6 @@ class S3PipelineExplorer(PipelineExplorer):
         body_bytes = io.BytesIO(obj['Body'].read())
         return gzip.GzipFile(fileobj=body_bytes, mode='rb')
 
-    def _filter(self, df, filters):
-        # simply check that filters are not mongo queries
-        for v in filters.values():
-            if isinstance(v, Mapping):
-                raise ValueError(
-                    'Must pass equality filters only to S3PipelineExplorer')
-        return super()._filter(df, filters)
-
     def _get_table(self, table_name):
         LOGGER.info("Downloading %s csv from S3", table_name)
         key = os.path.join('csvs', table_name + '.csv.gz')

--- a/piex/explorer.py
+++ b/piex/explorer.py
@@ -6,7 +6,6 @@ import json
 import logging
 import os
 import pickle
-from collections.abc import Mapping
 
 import boto3
 import botocore

--- a/piex/explorer.py
+++ b/piex/explorer.py
@@ -34,11 +34,14 @@ class PipelineExplorer:
     def _filter(self, df, filters):
         """Filter table df on equality filters
 
-        For example, if filters := ``{'data_modality': 'graph'}``, then only rows in the table that have the data_modality column equal to 'graph' will be returned.
+        For example, if filters := ``{'data_modality': 'graph'}``, then only
+        rows in the table that have the data_modality column equal to 'graph'
+        will be returned.
 
         Args:
             df (DataFrame)
-                filters (dict): mapping of column names -> values to check for equality
+                filters (dict): mapping of column names -> values to check for
+                    equality
         """
         df = df.loc[(df[list(filters)] == pd.Series(filters)).all(axis=1)]
         return df.reset_index(drop=True).copy()

--- a/piex/explorer.py
+++ b/piex/explorer.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import pickle
+from collections.abc import Mapping
 
 import boto3
 import botocore
@@ -249,6 +250,14 @@ class S3PipelineExplorer(PipelineExplorer):
         obj = self.client.get_object(Bucket=self.bucket, Key=key)
         body_bytes = io.BytesIO(obj['Body'].read())
         return gzip.GzipFile(fileobj=body_bytes, mode='rb')
+
+    def _filter(self, df, filters):
+        # simply check that filters are not mongo queries
+        for v in filters.values():
+            if isinstance(v, Mapping):
+                raise ValueError(
+                    'Must pass equality filters only to S3PipelineExplorer')
+        return super()._filter(df, filters)
 
     def _get_table(self, table_name):
         LOGGER.info("Downloading %s csv from S3", table_name)


### PR DESCRIPTION
Support `**filters` in more methods

Also, simplifies client creation in S3PipelineExplorer using `client` cached property and cleans up some other stuff.

Closes #8 